### PR TITLE
Updated pdftohtml to ignore drm problems

### DIFF
--- a/src/Job/ExtractOcr.php
+++ b/src/Job/ExtractOcr.php
@@ -368,7 +368,7 @@ class ExtractOcr extends AbstractJob
         $pdfFilepath = escapeshellarg($pdfFilepath);
         $xmlFilepath = escapeshellarg($xmlFilepath);
 
-        $command = "pdftohtml -i -c -hidden -xml $pdfFilepath $xmlFilepath";
+        $command = "pdftohtml -i -c -hidden -nodrm -xml $pdfFilepath $xmlFilepath";
 
         $result = $this->cli->execute($command);
         if ($result === false) {


### PR DESCRIPTION
Sometimes, pdf files can be locked to prevent editing. Adding the -nodrm option will bypass this